### PR TITLE
Fix autopilot and freeze camera

### DIFF
--- a/NFSU2ExtraOptions/HotkeyStuff.h
+++ b/NFSU2ExtraOptions/HotkeyStuff.h
@@ -88,6 +88,7 @@ void Thing()
 			else
 			{
 				Player_AutoPilotOff((DWORD*)PlayerThing);
+				Player_SetInputMode((void*)PlayerThing, 2);
 			}
 		}
 	}

--- a/NFSU2ExtraOptions/HotkeyStuff.h
+++ b/NFSU2ExtraOptions/HotkeyStuff.h
@@ -96,7 +96,20 @@ void Thing()
 	// Freeze Camera
 	if ((GetAsyncKeyState(hotkeyFreezeCamera) & 1) && (TheGameFlowManager == 6) && IsOnFocus)
 	{
-		*(bool*)_Camera_StopUpdating = !(*(bool*)_Camera_StopUpdating);
+		static BOOL isCameraFrozen = FALSE;
+		static const int call_near_size = 5;
+		static BYTE call_backup[call_near_size]; // in case of someone already placed hook there
+		static void* const call_SetCameraMatrix = (void*)0x453BF3;
+		if (isCameraFrozen) 
+		{
+			injector::WriteMemoryRaw(call_SetCameraMatrix, call_backup, call_near_size, true);
+		}
+		else 
+		{
+			memcpy(call_backup, call_SetCameraMatrix, call_near_size);
+			injector::MakeNOP(call_SetCameraMatrix, call_near_size);
+		}
+		isCameraFrozen ^= 1; // isCameraFrozen = !isCameraFrozen
 	}
 
 	if ((GetAsyncKeyState(hotkeyUnlockAllThings) & 1) && IsOnFocus) // Unlock All Things

--- a/NFSU2ExtraOptions/InGameFunctions.h
+++ b/NFSU2ExtraOptions/InGameFunctions.h
@@ -44,6 +44,7 @@ DWORD*(__cdecl* FEngFindPackage)(const char* pkg_name) = (DWORD*(__cdecl*)(const
 DWORD*(__cdecl* FEngFindString)(const char* pkg_name, DWORD ObjectHash) = (DWORD*(__cdecl*)(const char*, DWORD))0x537A10;
 void(__cdecl* FEngSetLanguageHash)(DWORD* FEString, DWORD LanguageHash) = (void(__cdecl*)(DWORD*, DWORD))0x50C900;
 void(__thiscall* sub_504820)(DWORD* Unk, BYTE something) = (void(__thiscall*)(DWORD*, BYTE))0x504820;
+void(__thiscall* Player_SetInputMode)(void* Player, int InputMode) = (void(__thiscall*)(void*, int))0x605C70;
 
 // Functions which has odd calling conventions (using UserCalls.h to wrap them)
 // none


### PR DESCRIPTION
Autopilot fix as in NFSU ExOpts.
Freeze camera fix:
Headlights wasn't moved with car when camera is frozen:
![unfixed](https://user-images.githubusercontent.com/59743349/148364790-03a0226b-dd14-4d65-b6d4-9781e13d35c6.png)
After fix:
![fixed](https://user-images.githubusercontent.com/59743349/148364935-79f79616-518d-467e-84c7-f30d21c186d2.png)

